### PR TITLE
Add logging configuration and async task logging

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,28 @@
+import asyncio
+import logging
+from src.config import LOG_LEVEL, LOG_FORMAT, LOG_FILE_PATH
+from src.tasks import sample_task
+
+def configure_logging() -> None:
+    """Configure application-wide logging."""
+    LOG_FILE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    logging.basicConfig(
+        level=LOG_LEVEL,
+        format=LOG_FORMAT,
+        handlers=[
+            logging.StreamHandler(),
+            logging.FileHandler(LOG_FILE_PATH)
+        ]
+    )
+
+async def run() -> None:
+    """Run sample asynchronous tasks."""
+    await sample_task()
+    try:
+        await sample_task(should_fail=True)
+    except Exception:
+        logging.getLogger(__name__).info("Handled exception from failing task")
+
+if __name__ == "__main__":
+    configure_logging()
+    asyncio.run(run())

--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,7 @@
+import logging
+from pathlib import Path
+
+# Logging configuration constants
+LOG_LEVEL = logging.INFO
+LOG_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+LOG_FILE_PATH = Path("logs/app.log")

--- a/src/tasks.py
+++ b/src/tasks.py
@@ -1,0 +1,21 @@
+import asyncio
+import logging
+
+logger = logging.getLogger(__name__)
+
+async def sample_task(should_fail: bool = False) -> None:
+    """A sample asynchronous task that logs its progress.
+
+    Args:
+        should_fail: If True, the task will raise an exception to demonstrate
+            logging of errors.
+    """
+    logger.info("Task started")
+    try:
+        await asyncio.sleep(0.1)
+        if should_fail:
+            raise ValueError("Simulated failure")
+        logger.info("Task completed successfully")
+    except Exception:
+        logger.exception("Task failed")
+        raise


### PR DESCRIPTION
## Summary
- add central logging constants for level, format, and file path
- configure logging in `main.py` and ensure asynchronous tasks log successes and errors

## Testing
- `python -m pytest`
- `python main.py`


------
https://chatgpt.com/codex/tasks/task_e_68a153fe8c6883289a2b237ac660db2d